### PR TITLE
refactor(zsh): improve plugin loading and modernize aliases

### DIFF
--- a/.aliases.zsh
+++ b/.aliases.zsh
@@ -10,7 +10,7 @@ command -v fd >/dev/null 2>&1 && alias find='fd'
 command -v htop >/dev/null 2>&1 && alias top='htop'
 command -v prettyping >/dev/null 2>&1 && alias ping='prettyping --nolegend'
 command -v procs >/dev/null 2>&1 && alias ps='procs'
-alias grep='grep --color=auto'
+grep --color=auto /dev/null 2>/dev/null && alias grep='grep --color=auto'
 
 # commands
 alias a="alias"

--- a/.aliases.zsh
+++ b/.aliases.zsh
@@ -6,11 +6,11 @@ command -v bat >/dev/null 2>&1 && alias cat='bat'
 command -v bat >/dev/null 2>&1 && alias less='bat --paging=always'
 command -v duf >/dev/null 2>&1 && alias df='duf'
 command -v eza >/dev/null 2>&1 && alias ls='eza'
-command -v ffind >/dev/null 2>&1 && alias find='ffind'
+command -v fd >/dev/null 2>&1 && alias find='fd'
 command -v htop >/dev/null 2>&1 && alias top='htop'
 command -v prettyping >/dev/null 2>&1 && alias ping='prettyping --nolegend'
 command -v procs >/dev/null 2>&1 && alias ps='procs'
-command -v rg >/dev/null 2>&1 && alias grep='rg'
+alias grep='grep --color=auto'
 
 # commands
 alias a="alias"
@@ -59,7 +59,7 @@ alias ll="ls -l --git"
 alias lt="ls -T --git --level=2"
 
 # git aliases
-alias gc='git cz'
+alias gcz='git cz'
 alias gac='git add -A && git commit -m'
 alias gcopy='git copy-branch-name'
 alias gd='git diff --color | sed "s/^\([^-+ ]*\)[-+ ]/\\1/" | diff-so-fancy' # Remove `+` and `-` from start of diff lines; just rely upon color.

--- a/.zshrc
+++ b/.zshrc
@@ -21,8 +21,8 @@ zstyle ':omz:update' mode auto
 COMPLETION_WAITING_DOTS="true"
 
 export HISTFILE=~/.zsh_history                         # Set history file location
-export HISTSIZE=10000                                  # More history in memory
-export SAVEHIST=10000                                  # More history on disk
+export HISTSIZE=100000                                 # More history in memory
+export SAVEHIST=100000                                 # More history on disk
 setopt INC_APPEND_HISTORY                              # Append history incrementally
 setopt HIST_IGNORE_ALL_DUPS                            # Ignore all duplicates
 
@@ -54,7 +54,6 @@ plugins=(
 	brew
 	copyfile
 	macos
-	thefuck
 	tldr
 )
 

--- a/.zshrc
+++ b/.zshrc
@@ -26,8 +26,9 @@ export SAVEHIST=100000                                 # More history on disk
 setopt INC_APPEND_HISTORY                              # Append history incrementally
 setopt HIST_IGNORE_ALL_DUPS                            # Ignore all duplicates
 
-# Tell oh-my-zsh to skip compinit — zsh-autocomplete calls it after oh-my-zsh loads
-skip_global_compinit=1
+# zsh-autocomplete calls compinit itself and must load last.
+# Only skip OMZ's compinit if the plugin is actually present.
+[[ -f "${HOMEBREW_PREFIX:-/opt/homebrew}/share/zsh-autocomplete/zsh-autocomplete.plugin.zsh" ]] && skip_global_compinit=1
 
 # Would you like to use another custom folder than $ZSH/custom?
 ZSH_CUSTOM=$HOME/repos/oh-my-zsh/custom
@@ -85,13 +86,14 @@ zstyle ':omz:plugins:alias-finder' longer yes # disabled by default
 zstyle ':omz:plugins:alias-finder' exact yes # disabled by default
 zstyle ':omz:plugins:alias-finder' cheaper yes # disabled by default
 
-# Set up syntax highlighting
-source ${HOMEBREW_PREFIX:-/opt/homebrew}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
-# Set up zsh-autosuggestions
-source ${HOMEBREW_PREFIX:-/opt/homebrew}/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+_brew_share="${HOMEBREW_PREFIX:-/opt/homebrew}/share"
+# Load order matters: syntax-highlighting → autosuggestions → autocomplete (owns compinit)
+[[ -f "$_brew_share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" ]] && source "$_brew_share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
+[[ -f "$_brew_share/zsh-autosuggestions/zsh-autosuggestions.zsh" ]] && source "$_brew_share/zsh-autosuggestions/zsh-autosuggestions.zsh"
 bindkey '^ ' autosuggest-accept
-# Set up zsh-autocomplete (calls compinit — must come after syntax-highlighting and autosuggestions)
-source ${HOMEBREW_PREFIX:-/opt/homebrew}/share/zsh-autocomplete/zsh-autocomplete.plugin.zsh
+# Must come last — calls compinit; if missing, OMZ falls back to calling compinit itself
+[[ -f "$_brew_share/zsh-autocomplete/zsh-autocomplete.plugin.zsh" ]] && source "$_brew_share/zsh-autocomplete/zsh-autocomplete.plugin.zsh"
+unset _brew_share
 
 # completions that require compinit (called above by zsh-autocomplete)
 eval "$(op completion zsh)"; compdef _op op

--- a/.zshrc
+++ b/.zshrc
@@ -95,7 +95,7 @@ _brew_share="${HOMEBREW_PREFIX:-/opt/homebrew}/share"
 [[ -f "$_brew_share/zsh-autocomplete/zsh-autocomplete.plugin.zsh" ]] && source "$_brew_share/zsh-autocomplete/zsh-autocomplete.plugin.zsh"
 unset _brew_share
 
-# completions that require compinit (called above by zsh-autocomplete)
+# completions that require compinit (provided above by zsh-autocomplete when available, otherwise by OMZ)
 eval "$(op completion zsh)"; compdef _op op
 if command -v ngrok &>/dev/null; then
 	eval "$(ngrok completion 2>/dev/null)"

--- a/.zshrc
+++ b/.zshrc
@@ -90,7 +90,7 @@ _brew_share="${HOMEBREW_PREFIX:-/opt/homebrew}/share"
 # Load order matters: syntax-highlighting → autosuggestions → autocomplete (owns compinit)
 [[ -f "$_brew_share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" ]] && source "$_brew_share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
 [[ -f "$_brew_share/zsh-autosuggestions/zsh-autosuggestions.zsh" ]] && source "$_brew_share/zsh-autosuggestions/zsh-autosuggestions.zsh"
-bindkey '^ ' autosuggest-accept
+(( $+widgets[autosuggest-accept] )) && bindkey '^ ' autosuggest-accept
 # Must come last — calls compinit; if missing, OMZ falls back to calling compinit itself
 [[ -f "$_brew_share/zsh-autocomplete/zsh-autocomplete.plugin.zsh" ]] && source "$_brew_share/zsh-autocomplete/zsh-autocomplete.plugin.zsh"
 unset _brew_share


### PR DESCRIPTION
## Summary

Improves shell configuration robustness by making plugin sourcing conditional on file existence, fixes plugin load order to respect zsh-autocomplete's compinit ownership, and updates aliases to use modern tool replacements.

## Changes

- **Plugin loading safety**: Wrap all Homebrew plugin sources in existence checks (`[[ -f ... ]] &&`) to gracefully handle missing installations
- **Load order fix**: Reorganize zsh-autocomplete, syntax-highlighting, and autosuggestions sourcing with explicit comments documenting the required order (syntax-highlighting → autosuggestions → autocomplete)
- **Conditional compinit skip**: Only set `skip_global_compinit=1` if zsh-autocomplete is actually present; falls back to OMZ's compinit otherwise
- **History expansion**: Increase `HISTSIZE` and `SAVEHIST` from 10,000 to 100,000 entries
- **Alias updates**:
  - Replace `ffind` with `fd` (modern find replacement)
  - Remove `rg` grep alias in favor of standard `grep --color=auto`
  - Rename `gc` to `gcz` to avoid conflict with git-commit conventions
- **Plugin removal**: Remove `thefuck` plugin from OMZ plugins list

## Implementation Details

- Introduced `_brew_share` variable to reduce path duplication and improve maintainability
- All plugin sources now follow the pattern: `[[ -f "$path" ]] && source "$path"` for defensive loading
- Comments clarify that zsh-autocomplete must load last as it calls compinit itself

https://claude.ai/code/session_01LcDwDN3CJjsCA4SaEsniKu