### PR TITLE
fix(zsh): make compinit handling robust without early path check

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -26,9 +26,8 @@ export SAVEHIST=100000                                 # More history on disk
 setopt INC_APPEND_HISTORY                              # Append history incrementally
 setopt HIST_IGNORE_ALL_DUPS                            # Ignore all duplicates
 
-# zsh-autocomplete calls compinit itself and must load last.
-# Only skip OMZ's compinit if the plugin is actually present.
-[[ -f "${HOMEBREW_PREFIX:-/opt/homebrew}/share/zsh-autocomplete/zsh-autocomplete.plugin.zsh" ]] && skip_global_compinit=1
+# OMZ must not call compinit — we handle it explicitly below (zsh-autocomplete or fallback)
+skip_global_compinit=1
 
 # Would you like to use another custom folder than $ZSH/custom?
 ZSH_CUSTOM=$HOME/repos/oh-my-zsh/custom
@@ -87,13 +86,17 @@ zstyle ':omz:plugins:alias-finder' exact yes # disabled by default
 zstyle ':omz:plugins:alias-finder' cheaper yes # disabled by default
 
 _brew_share="${HOMEBREW_PREFIX:-/opt/homebrew}/share"
-# Load order matters: syntax-highlighting → autosuggestions → autocomplete (owns compinit)
+# Load order matters: syntax-highlighting → autosuggestions → autocomplete (calls compinit)
 [[ -f "$_brew_share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" ]] && source "$_brew_share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
 [[ -f "$_brew_share/zsh-autosuggestions/zsh-autosuggestions.zsh" ]] && source "$_brew_share/zsh-autosuggestions/zsh-autosuggestions.zsh"
 (( $+widgets[autosuggest-accept] )) && bindkey '^ ' autosuggest-accept
-# Must come last — calls compinit; if missing, OMZ falls back to calling compinit itself
-[[ -f "$_brew_share/zsh-autocomplete/zsh-autocomplete.plugin.zsh" ]] && source "$_brew_share/zsh-autocomplete/zsh-autocomplete.plugin.zsh"
-unset _brew_share
+_zsh_autocomplete="$_brew_share/zsh-autocomplete/zsh-autocomplete.plugin.zsh"
+if [[ -f "$_zsh_autocomplete" ]]; then
+  source "$_zsh_autocomplete"       # calls compinit itself
+else
+  autoload -U compinit && compinit  # fallback: compinit if plugin is missing
+fi
+unset _brew_share _zsh_autocomplete
 
 # completions that require compinit (provided above by zsh-autocomplete when available, otherwise by OMZ)
 eval "$(op completion zsh)"; compdef _op op


### PR DESCRIPTION
Keep skip_global_compinit=1 unconditional so OMZ never calls compinit. Explicitly call compinit as fallback if zsh-autocomplete is missing, rather than relying on a path check that runs before HOMEBREW_PREFIX is guaranteed to be set.